### PR TITLE
Add rvslots:main to page query to avoid a deprecation warning from MediaWiki 1.32

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -180,7 +180,7 @@ func (w *Client) getPages(areNames bool, pageIDsOrNames ...string) (pages map[st
 			page.PageID = strconv.Itoa(entry.PageID)
 
 			rev := entry.Revisions[0]
-			page.Content = rev.Content
+			page.Content = rev.Slots.Main.Content
 			page.Timestamp = rev.Timestamp
 		}
 
@@ -210,7 +210,13 @@ type getPagesResponse struct {
 			Title     string `json:"title"`
 			Revisions []struct {
 				Timestamp string `json:"timestamp"`
-				Content   string `json:"content"`
+				Slots     struct {
+					Main struct {
+						ContentModel  string `json:"contentmodel"`
+						ContentFormat string `json:"contentformat"`
+						Content       string `json:"content"`
+					}
+				}
 			} `json:"revisions"`
 		} `json:"pages"`
 	} `json:"query"`

--- a/edit.go
+++ b/edit.go
@@ -114,9 +114,10 @@ func (w *Client) getPages(areNames bool, pageIDsOrNames ...string) (pages map[st
 	}
 
 	p := params.Values{
-		"action": "query",
-		"prop":   "revisions",
-		"rvprop": "content|timestamp",
+		"action":  "query",
+		"prop":    "revisions",
+		"rvprop":  "content|timestamp",
+		"rvslots": "main",
 	}
 	if areNames {
 		p.AddRange("titles", pageIDsOrNames...)


### PR DESCRIPTION
Retrieving content from page revisions needs an "rvslots" parameter to avoid a deprecation warning from MediaWiki 1.32. I haven't checked if it's needed anywhere other than edit.go: getPages.