### PR TITLE
Return data from getPages / getPage if a warning is received.

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -100,7 +100,7 @@ func (w *Client) getPage(pageIDorName string, isName bool) (content string, time
 	if pages != nil {
 		page := pages[pageIDorName]
 		if page.Error != nil {
-			err = page.Error
+			return "", "", page.Error
 		}
 		return page.Content, page.Timestamp, err
 	}


### PR DESCRIPTION
#9 I think this would do it. The change in getPage means that page errors will clobber any warnings, perhaps they should be appended instead.