### PR TITLE
Add ReplaceHTTPC, useful for OAuth with public keys.

### DIFF
--- a/core.go
+++ b/core.go
@@ -396,3 +396,11 @@ func (w *Client) OAuth(consumerToken, consumerSecret, accessToken, accessSecret 
 
 	return nil
 }
+
+// For the RSA OAuth authentication method, use oauth.NewRSAConsumer
+// and consumer.MakeHttpClient and install the http.Client here.
+func (w *Client) ReplaceHTTPC(httpc *http.Client) error {
+	httpc.Jar = w.httpc.Jar
+	w.httpc = httpc
+	return nil
+}


### PR DESCRIPTION
I am working on a tool, https://github.com/garyhouston/dtz, and discovered that if you select the RSA private key authentication method for OAuth at https://meta.wikimedia.org/ that there doesn't seem to be any way to make it work with go-mwclient. I added this function to allow installing a custom web client, as used in my authClient function. 