### PR TITLE
Support and automatically detect multipart encoding for parameters

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ ordered by date of first contribution:
 - Christoffer G. Thomsen
 - Gary Houston
 - hfern
+- Curtis Parfitt-Ford

--- a/core.go
+++ b/core.go
@@ -1,7 +1,6 @@
 package mwclient
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -190,17 +189,17 @@ func (w *Client) call(p params.Values, post bool) (io.ReadCloser, error) {
 		var err error
 		var multipartContentType string
 		if useMultipart {
-			var body *bytes.Buffer
+			var body string
 			body, multipartContentType, err = p.EncodeMultipart()
 
 			if err != nil {
 				return nil, fmt.Errorf("unable to encode parameters as multipart (params: %v): %v", p, err)
 			}
-			req, err = http.Post(w.apiURL.String(), body)
+			req, err = http.NewRequest("POST", w.apiURL.String(), strings.NewReader(body))
 		} else if post {
-			req, err = http.Post(w.apiURL.String(), strings.NewReader(p.Encode()))
+			req, err = http.NewRequest("POST", w.apiURL.String(), strings.NewReader(p.Encode()))
 		} else {
-			req, err = http.Get(fmt.Sprintf("%s?%s", w.apiURL.String(), p.Encode()), nil)
+			req, err = http.NewRequest("GET", fmt.Sprintf("%s?%s", w.apiURL.String(), p.Encode()), nil)
 		}
 
 		if err != nil {

--- a/core_test.go
+++ b/core_test.go
@@ -182,7 +182,7 @@ func TestMaxlagRetryFail(t *testing.T) {
 }
 
 func TestMultipartOffForSmallParameters(t *testing.T) {
-	smolH := strings.Repeat("h", 7500)
+	smallPayload := strings.Repeat("h", 7500)
 	httpHandler := func(w http.ResponseWriter, r *http.Request) {
 		err := r.ParseForm()
 		if err != nil {
@@ -191,7 +191,7 @@ func TestMultipartOffForSmallParameters(t *testing.T) {
 		if r.Method != "GET" {
 			t.Fatalf("bad HTTP method: %s", r.Method)
 		}
-		if r.Form.Get("test") != smolH {
+		if r.Form.Get("test") != smallPayload {
 			t.Fatalf("test param not set or incorrect. Params: %s", r.Form.Encode())
 		}
 	}
@@ -200,13 +200,13 @@ func TestMultipartOffForSmallParameters(t *testing.T) {
 	defer server.Close()
 
 	p := params.Values{
-		"test": smolH,
+		"test": smallPayload,
 	}
 	client.call(p, false)
 }
 
 func TestMultipartOnForLargeParameters(t *testing.T) {
-	bigH := strings.Repeat("h", 8500)
+	bigPayload := strings.Repeat("h", 8500)
 	httpHandler := func(w http.ResponseWriter, r *http.Request) {
 		err := r.ParseMultipartForm(10000)
 		if err != nil {
@@ -215,7 +215,7 @@ func TestMultipartOnForLargeParameters(t *testing.T) {
 		if r.Method != "POST" {
 			t.Fatalf("bad HTTP method: %s", r.Method)
 		}
-		if len(r.MultipartForm.Value["test"]) == 1 && r.MultipartForm.Value["test"][0] != bigH {
+		if len(r.MultipartForm.Value["test"]) == 1 && r.MultipartForm.Value["test"][0] != bigPayload {
 			t.Fatalf("test param not set or incorrect. Params: %s", r.PostForm.Encode())
 		}
 	}
@@ -224,7 +224,7 @@ func TestMultipartOnForLargeParameters(t *testing.T) {
 	defer server.Close()
 
 	p := params.Values{
-		"test": bigH,
+		"test": bigPayload,
 	}
 	client.call(p, false)
 }

--- a/edit.go
+++ b/edit.go
@@ -55,7 +55,7 @@ func (w *Client) Edit(p params.Values) error {
 
 	editResult, err := resp.GetString("edit", "result")
 	if err != nil {
-		return fmt.Errorf("unable to assert 'result' field to type string\n")
+		return fmt.Errorf("unable to assert 'result' field to type string")
 	}
 
 	if editResult != "Success" {

--- a/params/params.go
+++ b/params/params.go
@@ -13,7 +13,6 @@ package params // import "cgt.name/pkg/go-mwclient/params"
 import (
 	"bytes"
 	"mime/multipart"
-	"net/textproto"
 	"net/url"
 	"sort"
 	"strings"
@@ -105,7 +104,7 @@ func (v Values) EncodeMultipart() (*bytes.Buffer, string, error) {
 			continue
 		}
 		if v[paramName] != "" {
-			part, err := writer.CreatePart(textproto.MIMEHeader{"name": []string{paramName}})
+			part, err := writer.CreateFormField(paramName)
 			if err != nil {
 				return nil, "", err
 			}
@@ -114,7 +113,7 @@ func (v Values) EncodeMultipart() (*bytes.Buffer, string, error) {
 	}
 
 	if token {
-		part, err := writer.CreatePart(textproto.MIMEHeader{"name": []string{"token"}})
+		part, err := writer.CreateFormField("token")
 		if err != nil {
 			return nil, "", err
 		}

--- a/params/params.go
+++ b/params/params.go
@@ -12,7 +12,6 @@ package params // import "cgt.name/pkg/go-mwclient/params"
 
 import (
 	"bytes"
-	"io"
 	"mime/multipart"
 	"net/url"
 	"sort"
@@ -108,12 +107,12 @@ func (v Values) Encode() string {
 }
 
 // EncodeMultipart returns a ``multipart encoded'' version of
-// the parameters in an io.Reader, along with a Content-Type
+// the parameters as a string, along with a Content-Type
 // header string to use, and an error if something somehow
 // goes dramatically wrong.
-func (v Values) EncodeMultipart() (io.Reader, string, error) {
+func (v Values) EncodeMultipart() (data string, contentType string, err error) {
 	if v == nil {
-		return bytes.NewBuffer([]byte{}), "multipart/form-data; boundary=none", nil
+		return "", "multipart/form-data; boundary=none", nil
 	}
 
 	body := &bytes.Buffer{}
@@ -130,7 +129,7 @@ func (v Values) EncodeMultipart() (io.Reader, string, error) {
 		if v[paramName] != "" {
 			part, err := writer.CreateFormField(paramName)
 			if err != nil {
-				return nil, "", err
+				return "", "", err
 			}
 			part.Write([]byte(v[paramName]))
 		}
@@ -139,14 +138,14 @@ func (v Values) EncodeMultipart() (io.Reader, string, error) {
 	if token {
 		part, err := writer.CreateFormField("token")
 		if err != nil {
-			return nil, "", err
+			return "", "", err
 		}
 		part.Write([]byte(v["token"]))
 	}
 
 	writer.Close()
 
-	return body, writer.FormDataContentType(), nil
+	return body.String(), writer.FormDataContentType(), nil
 }
 
 // sortKeys sorts the keys of the parameters

--- a/params/params.go
+++ b/params/params.go
@@ -8,7 +8,7 @@
 // The purpose of this is that the MediaWiki API does not use multiple keys
 // to allow multiple values for a key (e.g., "a=b&a=c"). Instead it uses
 // one key with values separated by a pipe (e.g. "a=b|c").
-package params
+package params // import "cgt.name/pkg/go-mwclient/params"
 
 import (
 	"bytes"

--- a/params/params.go
+++ b/params/params.go
@@ -98,17 +98,18 @@ func (v Values) EncodeMultipart() (*bytes.Buffer, string, error) {
 
 	var token bool
 
-	for paramName, paramContents := range v {
+	keys := v.sortKeys()
+	for _, paramName := range keys {
 		if paramName == "token" {
 			token = true
 			continue
 		}
-		if paramContents != "" {
+		if v[paramName] != "" {
 			part, err := writer.CreatePart(textproto.MIMEHeader{"name": []string{paramName}})
 			if err != nil {
 				return nil, "", err
 			}
-			part.Write([]byte(paramContents))
+			part.Write([]byte(v[paramName]))
 		}
 	}
 
@@ -133,11 +134,7 @@ func (v Values) encode() string {
 	}
 
 	var buf bytes.Buffer
-	keys := make([]string, 0, len(v))
-	for k := range v {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	keys := v.sortKeys()
 	token := false
 	for _, k := range keys {
 		if k == "token" {
@@ -155,4 +152,16 @@ func (v Values) encode() string {
 		buf.WriteString("&token=" + url.QueryEscape(v["token"]))
 	}
 	return buf.String()
+}
+
+// sortKeys sorts the keys of the parameters
+// into an alphabetical order, to ensure that
+// the ordering is consistent
+func (v Values) sortKeys() []string {
+	keys := make([]string, 0, len(v))
+	for k := range v {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/params/params.go
+++ b/params/params.go
@@ -96,7 +96,13 @@ func (v Values) EncodeMultipart() (*bytes.Buffer, string, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
+	var token bool
+
 	for paramName, paramContents := range v {
+		if paramName == "token" {
+			token = true
+			continue
+		}
 		if paramContents != "" {
 			part, err := writer.CreatePart(textproto.MIMEHeader{"name": []string{paramName}})
 			if err != nil {
@@ -105,6 +111,15 @@ func (v Values) EncodeMultipart() (*bytes.Buffer, string, error) {
 			part.Write([]byte(paramContents))
 		}
 	}
+
+	if token {
+		part, err := writer.CreatePart(textproto.MIMEHeader{"name": []string{"token"}})
+		if err != nil {
+			return nil, "", err
+		}
+		part.Write([]byte(v["token"]))
+	}
+
 	writer.Close()
 
 	return body, writer.FormDataContentType(), nil

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -5,6 +5,7 @@
 package params
 
 import (
+	"io"
 	"strings"
 	"testing"
 )
@@ -36,8 +37,14 @@ func TestEncodeQuery(t *testing.T) {
 
 func TestEncodeMultipartQuery(t *testing.T) {
 	for _, tt := range encodeQueryTests {
-		buf, ctype, _ := tt.m.EncodeMultipart()
+		reader, ctype, _ := tt.m.EncodeMultipart()
 		valid := strings.ReplaceAll(tt.multipart, "!BOUNDARY!", strings.TrimPrefix(ctype, "multipart/form-data; boundary="))
+
+		buf := new(strings.Builder)
+		_, err := io.Copy(buf, reader)
+		if err != nil {
+			panic(err)
+		}
 		if buf.String() != valid {
 			t.Errorf(`EncodeMultipartQuery(%+v) = %q, want %q`, tt.m, buf.String(), valid)
 		}

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -5,7 +5,6 @@
 package params
 
 import (
-	"io"
 	"strings"
 	"testing"
 )
@@ -37,16 +36,11 @@ func TestEncodeQuery(t *testing.T) {
 
 func TestEncodeMultipartQuery(t *testing.T) {
 	for _, tt := range encodeQueryTests {
-		reader, ctype, _ := tt.m.EncodeMultipart()
+		enc, ctype, _ := tt.m.EncodeMultipart()
 		valid := strings.ReplaceAll(tt.multipart, "!BOUNDARY!", strings.TrimPrefix(ctype, "multipart/form-data; boundary="))
 
-		buf := new(strings.Builder)
-		_, err := io.Copy(buf, reader)
-		if err != nil {
-			panic(err)
-		}
-		if buf.String() != valid {
-			t.Errorf(`EncodeMultipartQuery(%+v) = %q, want %q`, tt.m, buf.String(), valid)
+		if enc != valid {
+			t.Errorf(`EncodeMultipartQuery(%+v) = %q, want %q`, tt.m, enc, valid)
 		}
 	}
 }

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -17,8 +17,8 @@ type EncodeQueryTest struct {
 
 var encodeQueryTests = []EncodeQueryTest{
 	{nil, "", ""},
-	{Values{"q": "puppies", "oe": "utf8"}, "oe=utf8&q=puppies", "--!BOUNDARY!\r\nname: q\r\n\r\npuppies\r\n--!BOUNDARY!\r\nname: oe\r\n\r\nutf8\r\n--!BOUNDARY!--\r\n"},
-	{Values{"x": "c", "token": "t", "a": "b"}, "a=b&x=c&token=t", "--!BOUNDARY!\r\nname: x\r\n\r\nc\r\n--!BOUNDARY!\r\nname: a\r\n\r\nb\r\n--!BOUNDARY!\r\nname: token\r\n\r\nt\r\n--!BOUNDARY!--\r\n"},
+	{Values{"q": "puppies", "oe": "utf8"}, "oe=utf8&q=puppies", "--!BOUNDARY!\r\nname: oe\r\n\r\nutf8\r\n--!BOUNDARY!\r\nname: q\r\n\r\npuppies\r\n--!BOUNDARY!--\r\n"},
+	{Values{"x": "c", "token": "t", "a": "b"}, "a=b&x=c&token=t", "--!BOUNDARY!\r\nname: a\r\n\r\nb\r\n--!BOUNDARY!\r\nname: x\r\n\r\nc\r\n--!BOUNDARY!\r\nname: token\r\n\r\nt\r\n--!BOUNDARY!--\r\n"},
 }
 
 func TestEncodeQuery(t *testing.T) {
@@ -32,8 +32,9 @@ func TestEncodeQuery(t *testing.T) {
 func TestEncodeMultipartQuery(t *testing.T) {
 	for _, tt := range encodeQueryTests {
 		buf, ctype, _ := tt.m.EncodeMultipart()
-		if buf.String() != strings.ReplaceAll(tt.multipart, "!BOUNDARY!", strings.TrimPrefix(ctype, "multipart/form-data; boundary=")) {
-			t.Errorf(`EncodeMultipartQuery(%+v) = %q, want %q`, tt.m, buf.String(), tt.multipart)
+		valid := strings.ReplaceAll(tt.multipart, "!BOUNDARY!", strings.TrimPrefix(ctype, "multipart/form-data; boundary="))
+		if buf.String() != valid {
+			t.Errorf(`EncodeMultipartQuery(%+v) = %q, want %q`, tt.m, buf.String(), valid)
 		}
 	}
 }

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -4,23 +4,36 @@
 
 package params
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 type EncodeQueryTest struct {
-	m        Values
-	expected string
+	m         Values
+	expected  string
+	multipart string
 }
 
 var encodeQueryTests = []EncodeQueryTest{
-	{nil, ""},
-	{Values{"q": "puppies", "oe": "utf8"}, "oe=utf8&q=puppies"},
-	{Values{"x": "c", "a": "b", "token": "t"}, "a=b&x=c&token=t"},
+	{nil, "", ""},
+	{Values{"q": "puppies", "oe": "utf8"}, "oe=utf8&q=puppies", "--!BOUNDARY!\r\nname: q\r\n\r\npuppies\r\n--!BOUNDARY!\r\nname: oe\r\n\r\nutf8\r\n--!BOUNDARY!--\r\n"},
+	{Values{"x": "c", "a": "b", "token": "t"}, "a=b&x=c&token=t", "--!BOUNDARY!\r\nname: x\r\n\r\nc\r\n--!BOUNDARY!\r\nname: a\r\n\r\nb\r\n--!BOUNDARY!\r\nname: token\r\n\r\nt\r\n--!BOUNDARY!--\r\n"},
 }
 
 func TestEncodeQuery(t *testing.T) {
 	for _, tt := range encodeQueryTests {
 		if q := tt.m.Encode(); q != tt.expected {
 			t.Errorf(`EncodeQuery(%+v) = %q, want %q`, tt.m, q, tt.expected)
+		}
+	}
+}
+
+func TestEncodeMultipartQuery(t *testing.T) {
+	for _, tt := range encodeQueryTests {
+		buf, ctype, _ := tt.m.EncodeMultipart()
+		if buf.String() != strings.ReplaceAll(tt.multipart, "!BOUNDARY!", strings.TrimPrefix(ctype, "multipart/form-data; boundary=")) {
+			t.Errorf(`EncodeMultipartQuery(%+v) = %q, want %q`, tt.m, buf.String(), tt.multipart)
 		}
 	}
 }

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -17,8 +17,13 @@ type EncodeQueryTest struct {
 
 var encodeQueryTests = []EncodeQueryTest{
 	{nil, "", ""},
-	{Values{"q": "puppies", "oe": "utf8"}, "oe=utf8&q=puppies", "--!BOUNDARY!\r\nname: oe\r\n\r\nutf8\r\n--!BOUNDARY!\r\nname: q\r\n\r\npuppies\r\n--!BOUNDARY!--\r\n"},
-	{Values{"x": "c", "token": "t", "a": "b"}, "a=b&x=c&token=t", "--!BOUNDARY!\r\nname: a\r\n\r\nb\r\n--!BOUNDARY!\r\nname: x\r\n\r\nc\r\n--!BOUNDARY!\r\nname: token\r\n\r\nt\r\n--!BOUNDARY!--\r\n"},
+	{Values{"q": "puppies", "oe": "utf8"}, "oe=utf8&q=puppies", "--!BOUNDARY!\r\nContent-Disposition: form-data; name=\"oe\"\r\n\r\nutf8\r\n" +
+		"--!BOUNDARY!\r\nContent-Disposition: form-data; name=\"q\"\r\n\r\npuppies\r\n" +
+		"--!BOUNDARY!--\r\n"},
+	{Values{"x": "c", "token": "t", "a": "b"}, "a=b&x=c&token=t", "--!BOUNDARY!\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\nb\r\n" +
+		"--!BOUNDARY!\r\nContent-Disposition: form-data; name=\"x\"\r\n\r\nc\r\n" +
+		"--!BOUNDARY!\r\nContent-Disposition: form-data; name=\"token\"\r\n\r\nt\r\n" +
+		"--!BOUNDARY!--\r\n"},
 }
 
 func TestEncodeQuery(t *testing.T) {

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -18,7 +18,7 @@ type EncodeQueryTest struct {
 var encodeQueryTests = []EncodeQueryTest{
 	{nil, "", ""},
 	{Values{"q": "puppies", "oe": "utf8"}, "oe=utf8&q=puppies", "--!BOUNDARY!\r\nname: q\r\n\r\npuppies\r\n--!BOUNDARY!\r\nname: oe\r\n\r\nutf8\r\n--!BOUNDARY!--\r\n"},
-	{Values{"x": "c", "a": "b", "token": "t"}, "a=b&x=c&token=t", "--!BOUNDARY!\r\nname: x\r\n\r\nc\r\n--!BOUNDARY!\r\nname: a\r\n\r\nb\r\n--!BOUNDARY!\r\nname: token\r\n\r\nt\r\n--!BOUNDARY!--\r\n"},
+	{Values{"x": "c", "token": "t", "a": "b"}, "a=b&x=c&token=t", "--!BOUNDARY!\r\nname: x\r\n\r\nc\r\n--!BOUNDARY!\r\nname: a\r\n\r\nb\r\n--!BOUNDARY!\r\nname: token\r\n\r\nt\r\n--!BOUNDARY!--\r\n"},
 }
 
 func TestEncodeQuery(t *testing.T) {


### PR DESCRIPTION
Fixes #14. Any request that has a parameter value of string length greater than 8000 will be converted automatically to a POSTed multipart request. All MW API endpoints support this sort of request, so there shouldn't be any issue with it being POST and not GET (I checked this with Reedy from the MediaWiki dev team) - and it's handled automatically by the library, so it oughtn't get in the way of any implementations.

Note that, whilst I've written tests for the new methods and all seems to be working well, I've not tested this against the actual MediaWiki API yet - mostly because it's a huge pain to do so without Go Modules in the repository, as it seems to mean that to override the package in testing, you have to change the `//import` comments, then change all of the actual `import`s too, to make it somewhere on your hard disk. I may be missing something obvious though! Either way, this _should_ do what it says on the tin (and Golang's multipart parser is perfectly happy with it, per the tests).